### PR TITLE
Auto-bump: @primer/gatsby-theme-doctocat@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "now-build": "yarn run build"
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "^0.25.3",
+    "@primer/gatsby-theme-doctocat": "^1.0.0",
     "gatsby": "^2.13.25",
     "react": "^16.13.0",
     "react-dom": "^16.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,16 +1327,17 @@
     react-is "16.10.2"
     styled-system "5.1.2"
 
-"@primer/gatsby-theme-doctocat@^0.25.3":
-  version "0.25.3"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.25.3.tgz#9ca4003bc030a093f1d86c5ba46c3e3fc224332a"
-  integrity sha512-gbX/v7t/OyrNnt9mbiuyOYajJtEnNSJNOQUcRfLhzT0qxIQhM0X7uszxDQIEmACU/xBuDMghISnRxDC87Zxubw==
+"@primer/gatsby-theme-doctocat@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-1.0.0.tgz#e2412b1ce25bcb49d291b512491295ad24000a65"
+  integrity sha512-ZrZpdgs7Xpio1ZR6fihe9ISTWFXUXTR2WJKtHQJnp0k1WFI9CmqGXTnpJC9dlY/62wLp5rLCGlWr3dRM6KTE4A==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"
     "@mdx-js/mdx" "^1.0.21"
     "@mdx-js/react" "^1.0.21"
     "@primer/components" "^20.0.0"
+    "@primer/octicons-react" "^11.0.0"
     "@styled-system/theme-get" "^5.0.12"
     "@testing-library/jest-dom" "^4.1.0"
     "@testing-library/react" "^9.1.3"
@@ -1385,6 +1386,11 @@
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-10.0.0.tgz#82f0d64b4276778fb51468afac00aa0c420ad230"
   integrity sha512-I+m7Srg/Ivo5VuXoKwKCJ6YJya+lr6EVzp/WGnDlwBSpy0m4WfYAmZigt3A0i4JMqgLRFDlK+8AgqT66E9bOOw==
+
+"@primer/octicons-react@^11.0.0":
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-11.0.0.tgz#8171177a55d944c9e6b491c43f2957e86191cfa5"
+  integrity sha512-lHEoFVhTyyjxIDJJgVQBJGsEU4BywFbpHuBPDM8jpqYszGcYaV3zCLWNCUaQgLfzl3lRBUXc+pMrzT5qRXLftg==
 
 "@primer/primitives@3.0.0":
   version "3.0.0"


### PR DESCRIPTION
Auto-upgrade of `@primer/gatsby-theme-doctocat` to `1.0.0` via multibump.