### PR TITLE
Fixes broken link to color a11y guidelines

### DIFF
--- a/content/foundations/color.mdx
+++ b/content/foundations/color.mdx
@@ -14,4 +14,4 @@ Terminals reliably recognize the 8 basic ANSI colors. There are also bright vers
 - Background color is available but we haven’t taken advantage of it yet.
 - Some terminals do not reliably support 256-color escape sequences.
 - Users can customize their how their terminal displays the 8 basic colors, but that’s opt-in (for example, the user knows they’re making their greens not green).
-- Only use color to [enhance meaning](https://primer.style/design/global/accessibility#visual-accessibility), not to communicate meaning.
+- Only use color to [enhance meaning](https://primer.style/design/accessibility/guidelines#use-of-color), not to communicate meaning.


### PR DESCRIPTION
The previous link results in a 404. I read the latest guidelines and linked to the place that made the most sense